### PR TITLE
Add option to use old 32bit mode for ZIP for legacy applications.

### DIFF
--- a/Objective-Zip/ZipFile.h
+++ b/Objective-Zip/ZipFile.h
@@ -62,9 +62,11 @@ typedef enum {
 @private
 	zipFile _zipFile;
 	unzFile _unzFile;
+    BOOL    _using64;
 }
 
 - (id) initWithFileName:(NSString *)fileName mode:(ZipFileMode)mode;
+- (id) initWithFileName:(NSString *)fileName mode:(ZipFileMode)mode allow64Mode: (BOOL) allow64Mode;
 
 - (ZipWriteStream *) writeFileInZipWithName:(NSString *)fileNameInZip compressionLevel:(ZipCompressionLevel)compressionLevel;
 - (ZipWriteStream *) writeFileInZipWithName:(NSString *)fileNameInZip fileDate:(NSDate *)fileDate compressionLevel:(ZipCompressionLevel)compressionLevel;
@@ -77,6 +79,7 @@ typedef enum {
 - (void) goToFirstFileInZip;
 - (BOOL) goToNextFileInZip;
 - (BOOL) locateFileInZip:(NSString *)fileNameInZip;
+- (BOOL) isUsing64Bit;
 
 - (FileInZipInfo *) getCurrentFileInZipInfo;
 


### PR DESCRIPTION
* ZipFile has additional constructor with allow64Mode boolean parameter, if false is specified, old mode is used, not ZIP64.
* Useful for creating ZIP archives that are processed on Android where libraries usually don't have support for ZIP64.