### PR TITLE
Changed throwing of Swift errors 

### DIFF
--- a/Objective-Zip/OZZipFile+NSError.h
+++ b/Objective-Zip/OZZipFile+NSError.h
@@ -231,7 +231,7 @@ static const NSInteger OZLocateFileResultFound= 1;
  @throws OZZipException If the zip file has been opened with a mode other than
  Unzip.
  */
-- (NSInteger) __attribute__((swift_error(zero_result))) locateFileInZip:(nonnull NSString *)fileNameInZip error:(NSError * __autoreleasing __nullable * __nullable)error;
+- (NSInteger) __attribute__((swift_error(nonnull_error))) locateFileInZip:(nonnull NSString *)fileNameInZip error:(NSError * __autoreleasing __nullable * __nullable)error;
 
 /**
  @brief Returns the number of files contained in the zip file.
@@ -242,7 +242,7 @@ static const NSInteger OZLocateFileResultFound= 1;
  @throws OZZipException If the zip file has been opened with a mode other
  than Unzip.
  */
-- (NSUInteger) __attribute__((swift_error(zero_result))) numFilesInZipWithError:(NSError * __autoreleasing __nullable * __nullable)error;
+- (NSUInteger) __attribute__((swift_error(nonnull_error))) numFilesInZipWithError:(NSError * __autoreleasing __nullable * __nullable)error;
 
 /**
  @brief Returns a list of OZFileInZipInfo with the information on all the files

--- a/Objective-Zip/OZZipReadStream+NSError.h
+++ b/Objective-Zip/OZZipReadStream+NSError.h
@@ -58,7 +58,7 @@ static const NSInteger OZReadStreamResultEndOfFile= -1;
  <br/>NOTE: return value convention is different in the standard (non-NSError
  compliant) interface.
  */
-- (NSInteger) __attribute__((swift_error(zero_result))) readDataWithBuffer:(nonnull NSMutableData *)buffer error:(NSError * __autoreleasing __nullable * __nullable)error;
+- (NSInteger) __attribute__((swift_error(nonnull_error))) readDataWithBuffer:(nonnull NSMutableData *)buffer error:(NSError * __autoreleasing __nullable * __nullable)error;
 
 /**
  @brief Closes the read steam.


### PR DESCRIPTION
Changed throwing of Swift errors from the Stream reading/writing to be nonnull_error rather than zero_result. Continues to work with Swift 2.x but now will work with Swift 3 Beta (circa XCode 8 beta 6)