### PR TITLE
fix documentation warning

### DIFF
--- a/Objective-Zip/OZZipException.h
+++ b/Objective-Zip/OZZipException.h
@@ -39,7 +39,7 @@ extern const NSInteger OZ_ERROR_NO_SUCH_FILE;
 /**
  @brief OZZipException is a custom exception type to quickly discern between
  error originated during the zip/unzip process or elsewhere.
- </p>All exceptions thrown by Objective-Zip are of OZZipException type.</p>
+ <p>All exceptions thrown by Objective-Zip are of OZZipException type.</p>
  */
 @interface OZZipException : NSException 
 


### PR DESCRIPTION
Compiler is giving a warning because the `<p>` start tag is accidentally an end tag
![image](https://user-images.githubusercontent.com/1833895/30944975-7ba5eb2e-a3c9-11e7-80ac-1d8589b1cc8b.png)
